### PR TITLE
Update source as well as documentation with respect to slurm 20.02.4 …

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,29 +3,48 @@ gres_plugin for Slurm
 It allows for scheduling whole aurora cards on nodes using gres in Slurm but not to share one aurora between jobs. 
 
 Checkout https://github.com/henkela/SX-Aurora-Slurm-Plugin/releases for the latest release. 
-This has not yet been tested on 18.08.xx.
+This has been tested on 20.02.4.
 
 ## Getting started
 ### Compiling 
 You should be used to compiling custom code for Slurm. Briefly:
 1. Clone this repo to src/plugins/gres/aurora in your local copy of Slurm or unpack the release tarball and copy the files to that folder
-2. Add ''src/plugins/gres/aurora/Makefile'' to the configure.ac file
-3. Run ./autogen.sh 
-4. Add aurora to src/plugins/gres/aurora/Makefile.am 
-5. Run ./configure --prefix=<your slurm install>
-6. make && make install if this is a new Slurm-source-tree. 
+2. Add ''src/plugins/gres/aurora/Makefile'' to the configure.ac file in the slurm root directory
+3. rm existing configure file
+4. Add ''aurora'' to the SUBDIRS variable in src/plugins/gres/aurora/Makefile.am
+5. Run autoreconf
+6. make && make install if this is a new Slurm-source-tree. or patch the slurm.spec file
   
 I would strongly advise to build a separate slurm cluster on the aurora-nodes for testing (that's at least how I did it; mind that slurmctld and slurmdbd are needed because of the gres-usage. And don't forget to change the Ports in the slurm.conf if you have other slurmctlds running) because many things can go wrong while doing the reconfiguration which may crash the slurmctld which in turn would be "suboptimal" in a productive cluster. Once you have everything up and running with the test-cluster, you can move it to the productive environment. 
 
 ### Slurm-Configuration
-1. You should have the nodes configured in your slurm.conf or an approriate include file. The node definition should look similar to 
+1. You should have the nodes configured in your slurm.conf or an approriate include file. The node definition should look similar to
   ```bash
-  Nodename=<nodename> Gres=aurora:<count> 
+  GresTypes=aurora
+  SelectType=select/cons_tres
+  Nodename=<nodename> Gres=aurora:<count>
   ```
+
+  If you have multiple VEs per VH and want to share them between different jobs, you have to create a shared parition like the one below
+  In this case it is also recommended to define CPUs as well as memory of the nodes as shared resources like in the example below with two A100
+  ```bash
+  GresTypes=aurora
+  SelectType=select/cons_tres
+  SelectTypeParameters=CR_Core_Memory
+  NoneName=vh[100-101] CPUs=80 Sockets=2 CoresPerSocket=20 ThreadsPerCore=2 RealMemory=192078 Gres=aurora:8
+  PartitionName=aurora Shared=Yes Nodes=vh[100-101]
+  ```
+
 2. You gres.conf should contain at least: 
   ```bash 
-  Nodename=<nodename> File=/dev/veslot[0,1] 
+  Nodename=<nodename> File=/dev/veslot[<ve slot numbers as csv>]
   ```
+
+  So for the example with the two A100 it would be
+  ```bash
+  NodeName=vh0t[100-101] Name=aurora File=/dev/veslot[0,1,2,3,4,5,6,7]
+  ```
+
 3. Your cgroups.conf needs to have ContrainDevices=yes, which raises the necessity for 
 4. you need cgroup_allowed_devices_file.conf to contain at the very least (but check slurm-doku on that, please)
   ```bash 
@@ -39,3 +58,12 @@ srun -n1 --gres=aurora:1 -p<yourpartition> env|sort
 ```
   
 and check for SLURM-variables being set, i.e. VE_NODE_NUMBER should also be there. 
+
+The example below show two slurm jobs with 4 VEs each, that run on the same A100 in parallel
+
+  ```bash
+  VE_NODE_NUMBER=0,1,2,3                                       |  VE_NODE_NUMBER=0,1,2,3
+  AURORA_VISIBLE_DEVICES=0,1,2,3                               |  AURORA_VISIBLE_DEVICES=0,1,2,3
+  SLURM_JOBID=30                                               |  SLURM_JOBID=31
+  SLURM_JOB_AURORAS=0,1,2,3                                    |  SLURM_JOB_AURORAS=4,5,6,7
+  ```

--- a/gres_aurora.c
+++ b/gres_aurora.c
@@ -39,7 +39,7 @@
 #include "src/common/env.h"
 #include "src/common/gres.h"
 #include "src/common/list.h"
-#include "src/common/xcgroup_read_config.c"
+#include "src/common/xcgroup_read_config.h"
 #include "src/common/xstring.h"
 
 #include "../common/gres_common.h"
@@ -72,18 +72,28 @@
 const char	plugin_name[]		= "Gres Aurora plugin";
 const char	plugin_type[]		= "gres/aurora";
 const uint32_t	plugin_version		= SLURM_VERSION_NUMBER;
-
 static char	gres_name[]		= "aurora";
-
 static List gres_devices = NULL;
+
+extern void step_hardware_init(bitstr_t *usable_auroras, char *tres_setting)
+{
+//	gpu_g_step_hardware_init(usable_gpus, tres_freq);
+//	Maybe we can set at this point the numa mode of the VE(s)
+	debug("%s: %s TODO: implement functionality", __func__, plugin_name);
+}
+
+extern void step_hardware_fini(void)
+{
+//	gpu_g_step_hardware_fini();
+	debug("%s: %s TODO: implement functionality", __func__, plugin_name);
+}
 
 static void _set_env(char ***env_ptr, void *gres_ptr, int node_inx,
 		     bitstr_t *usable_gres,
 		     bool *already_seen, int *local_inx,
 		     bool reset, bool is_job)
 {
-	char *global_list = NULL, *local_list = NULL;
-	char *slurm_env_var = NULL;
+	char *global_list = NULL, *local_list = NULL, *slurm_env_var = NULL;
 
 	if (is_job)
 			slurm_env_var = "SLURM_JOB_AURORAS";
@@ -97,9 +107,9 @@ static void _set_env(char ***env_ptr, void *gres_ptr, int node_inx,
 	}
 
 	common_gres_set_env(gres_devices, env_ptr, gres_ptr, node_inx,
-			    usable_gres, "", local_inx,
+			    usable_gres, "", local_inx, NULL,
 			    &local_list, &global_list,
-			    reset, is_job);
+			    reset, is_job, NULL);
 
 	if (global_list) {
 		env_array_overwrite(env_ptr, slurm_env_var, global_list);
@@ -135,7 +145,7 @@ extern int fini(void)
  * This only validates that the configuration was specified in gres.conf.
  * In the general case, no code would need to be changed.
  */
-extern int node_config_load(List gres_conf_list)
+extern int node_config_load(List gres_conf_list, node_config_load_t *node_config)
 {
 	int rc = SLURM_SUCCESS;
 
@@ -226,4 +236,41 @@ extern int step_info(gres_step_state_t *step_gres_data, uint32_t node_inx,
 extern List get_devices(void)
 {
 	return gres_devices;
+}
+
+/*
+ * Build record used to set environment variables as appropriate for a job's
+ * prolog or epilog based GRES allocated to the job.
+ */
+extern gres_epilog_info_t *epilog_build_env(gres_job_state_t *gres_job_ptr)
+{
+	int i;
+	gres_epilog_info_t *epilog_info;
+
+	epilog_info = xmalloc(sizeof(gres_epilog_info_t));
+	epilog_info->node_cnt = gres_job_ptr->node_cnt;
+	epilog_info->gres_bit_alloc = xcalloc(epilog_info->node_cnt,
+					      sizeof(bitstr_t *));
+	for (i = 0; i < epilog_info->node_cnt; i++) {
+		if (gres_job_ptr->gres_bit_alloc &&
+		    gres_job_ptr->gres_bit_alloc[i]) {
+			epilog_info->gres_bit_alloc[i] =
+				bit_copy(gres_job_ptr->gres_bit_alloc[i]);
+		}
+	}
+
+	debug("%s: %s TODO: check functionality", __func__, plugin_name);
+
+	return epilog_info;
+}
+
+/*
+ * Set environment variables as appropriate for a job's prolog or epilog based
+ * GRES allocated to the job.
+ */
+extern void epilog_set_env(char ***epilog_env_ptr,
+			   gres_epilog_info_t *epilog_info, int node_inx)
+{
+	debug("%s: %s TODO: implement functionality", __func__, plugin_name);
+	return;
 }


### PR DESCRIPTION
…source

With some minor modifications it is possible to patch the slurm sources to build rpms through rpmbuild

The patched version was tested with a containerized centos7 slurm 20.02.4 and a single A100

It was possible to start multiple single as well as multi Aurora jobs simultaneously on the A100.
ve_exec in combination with the ''VE_NODE_NUMBER'' environment variable were used for this.

The usage of the Auroras were successfully restricted to the assigned ones.

MISSING TESTS:
- multinode
- MPI